### PR TITLE
Added voiding of Iron.Router routes by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ meteor add mixmax:smart-disconnect
 ## Meteor Settings
 You can change the time for which the user is away for before you disconnect. By default this value is 60 seconds, but you can set `disconnectTimeSec` in your Meteor settings file to a different value to change this. This value is in seconds and `disconnectTimeSec` should be a public value in your settings file.
 
+If you are using the Iron Router package, you can stop the smart-disconnect from working on some of your routes by adding a `disconnectVoids` key into the public section of your settings file. It must be an array of route names such as:
+
+    "disconnectVoids" : ["Dashboard","Account","Profile"]
+
 ## Contributing
 
 We welcome all contributions! Please enhance this with more logic to disconnect in a smart way. Some ideas:

--- a/disconnect-when-backgrounded.js
+++ b/disconnect-when-backgrounded.js
@@ -2,6 +2,7 @@ var disconnectTimer = null;
 
 // 60 seconds by default
 var disconnectTime = (Meteor.settings && Meteor.settings.public && Meteor.settings.public.disconnectTimeSec || 60) * 1000;
+var disconnectVoids = (Meteor.settings && Meteor.settings.public && Meteor.settings.public.disconnectVoids || []);
 
 Meteor.startup(disconnectIfHidden);
 
@@ -16,7 +17,9 @@ function disconnectIfHidden() {
     removeDisconnectTimeout();
 
     if (document.hidden) {
-        createDisconnectTimeout();
+        if((Package["iron:router"] && disconnectVoids.indexOf(Router.current().route.getName()) < 0) || (!Package["iron:router"])){
+            createDisconnectTimeout();
+        }
     } else {
         Meteor.reconnect();
     }

--- a/disconnect-when-backgrounded.js
+++ b/disconnect-when-backgrounded.js
@@ -17,7 +17,7 @@ function disconnectIfHidden() {
     removeDisconnectTimeout();
 
     if (document.hidden) {
-        if((Package["iron:router"] && disconnectVoids.indexOf(Router.current().route.getName()) < 0) || (!Package["iron:router"])){
+        if(!Package["iron:router"] || disconnectVoids.indexOf(Router.current().route.getName()) < 0){
             createDisconnectTimeout();
         }
     } else {


### PR DESCRIPTION
If the iron:router package is installed then when applying the createDisconnectTimeout() function it will check to see if the current route's name is in a list of voids from Meteor.settings. If yes it won't disconnect otherwise it will.