### PR TITLE
feat: disconnect voids by pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ If you are using the Iron Router package, you can stop the smart-disconnect from
 
     "disconnectVoids" : ["Dashboard","Account","Profile"]
 
+If you are not using the Iron Router package, you can stop the smart-disconnect from working on some of your routes by passing their pathname:
+
+    "disconnectVoids": ["/dashboard/account", "/dashboard/settings"]
+
 ## Contributing
 
 We welcome all contributions! Please enhance this with more logic to disconnect in a smart way. Some ideas:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ If you are not using the Iron Router package, you can stop the smart-disconnect 
 
     "disconnectVoids": ["/dashboard/account", "/dashboard/settings"]
 
+## Check Disconnect & Reconnect
+
+You can test whether you are connected or disconnected by using Meteor's Tracker package:
+
+```
+import { Tracker } from 'meteor/tracker';
+
+export const MyComponent = () => {
+    Tracker.autorun(() => {
+        console.log(Meteor.status().status);
+    });
+}
+```
+
+This will console log your connection status as it changes.
+
+It can be helpful to include timestamps as well:
+
+```
+Tracker.autorun(() => {
+    console.log(`${new Date().toLocaleTimeString('en-GB')} : ${Meteor.status().status}`);
+});
+```
+
 ## Contributing
 
 We welcome all contributions! Please enhance this with more logic to disconnect in a smart way. Some ideas:

--- a/disconnect-when-backgrounded.js
+++ b/disconnect-when-backgrounded.js
@@ -13,10 +13,12 @@ if (Meteor.isCordova) {
     document.addEventListener('pause', function () { createDisconnectTimeout(); });
 }
 
+const currentPageIsNotExempt = () => { return disconnectVoids.indexOf(window.location.pathname) == -1; };
+
 function disconnectIfHidden() {
     removeDisconnectTimeout();
 
-    if (document.hidden) {
+    if (document.hidden && currentPageIsNotExempt()) {
         if(!Package["iron:router"] || disconnectVoids.indexOf(Router.current().route.getName()) < 0){
             createDisconnectTimeout();
         }

--- a/disconnect-when-backgrounded.js
+++ b/disconnect-when-backgrounded.js
@@ -13,15 +13,16 @@ if (Meteor.isCordova) {
     document.addEventListener('pause', function () { createDisconnectTimeout(); });
 }
 
-const currentPageIsNotExempt = () => { return disconnectVoids.indexOf(window.location.pathname) == -1; };
+function currentPageIsNotExempt() {
+    const pathName = Package["iron:router"] ? Router.current().route.getName() : window.location.pathname;
+    return !disconnectVoids.includes(pathName);
+};
 
 function disconnectIfHidden() {
     removeDisconnectTimeout();
 
     if (document.hidden && currentPageIsNotExempt()) {
-        if(!Package["iron:router"] || disconnectVoids.indexOf(Router.current().route.getName()) < 0){
-            createDisconnectTimeout();
-        }
+        createDisconnectTimeout();
     } else {
         Meteor.reconnect();
     }


### PR DESCRIPTION
#### Changes Made

1. Disconnect voids based on pathname (so that smart-disconnect can be stopped on certain pages when not using FlowRouter)

2. Explain how to check the connection status using Meteor.status() - similar to [this](https://github.com/mixmaxhq/meteor-smart-disconnect/issues/8) issue.

#### Potential Risks
I am not aware of any potential risks.  The change is fairly simple and should not affect the other conditions for disconnecting or reconnecting. 

#### Test Plan
I have done manual testing to ensure that the change works.  However, I have not tested that it still works with FlowRouter.

#### Checklist
- [ ] I've increased test coverage
- [X] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
